### PR TITLE
Menu left not show when is long content Fixes #6

### DIFF
--- a/css/sb-admin.css
+++ b/css/sb-admin.css
@@ -123,6 +123,9 @@ ul.alert-dropdown {
         border-radius: 0;
         overflow-y: auto;
         background-color: #222;
+        bottom: 0;
+        overflow-x: hidden;
+        padding-bottom: 40px;
     }
 
     .side-nav>li>a {


### PR DESCRIPTION
Now, If we have a long menu items or small device we can see the menu by scrolling : http://i.imgur.com/qsJey3X.png